### PR TITLE
[#8130951] Makes timeout and open_timeout configurable.

### DIFF
--- a/lib/clever-ruby.rb
+++ b/lib/clever-ruby.rb
@@ -61,6 +61,20 @@ module Clever
       configuration.api_key
     end
 
+    # Retrieve the configured timeout
+    # @api private
+    # @return [Fixnum] Configuration timeout
+    def timeout
+      configuration.timeout
+    end
+
+    # Retrieve the configured open timeout
+    # @api private
+    # @return [Fixnum] Open timeout
+    def open_timeout
+      configuration.open_timeout
+    end
+
     # Retrieve your stored API token
     # @api private
     # @return [String] API token
@@ -134,9 +148,9 @@ module Clever
       method: method,
       url: url,
       headers: headers,
-      open_timeout: 30,
+      open_timeout: Clever.open_timeout,
       payload: payload,
-      timeout: 120
+      timeout: Clever.timeout
     }
     if Clever.api_key
       opts[:user] = Clever.api_key

--- a/lib/clever-ruby/configuration.rb
+++ b/lib/clever-ruby/configuration.rb
@@ -16,6 +16,16 @@ module Clever
     # @return [String]
     attr_accessor :api_base
 
+    # Access API timeout
+    # @api private
+    # @return [Fixnum]
+    attr_accessor :timeout
+
+    # Access API open timeout
+    # @api private
+    # @return [Fixnum]
+    attr_accessor :open_timeout
+
     # Initialize configuration
     # @api private
     # @return [Clever::Configuration]
@@ -23,6 +33,8 @@ module Clever
       @api_key  = nil
       @token = nil
       @api_base = 'https://api.clever.com/'
+      @timeout = 120
+      @open_timeout = 30
     end
   end
 end


### PR DESCRIPTION
This PR makes the timeout and open timeout options on Clever requests configurable. They continue to default to 30 and 120 respectively.

``` ruby
Clever.configure do |config|
  config.timeout = 40
  config.open_timeout = 130
end
```
