### PR TITLE
Jnm+cg/authed events

### DIFF
--- a/clever-ruby.gemspec
+++ b/clever-ruby.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'minitest-vcr',  '~> 0.1.1'
   gem.add_development_dependency 'webmock',       '~> 1.9.0'
   gem.add_development_dependency 'rubocop',       '~> 0.26.0'
+  gem.add_development_dependency 'pry',           '~> 0.10.3'
 end

--- a/lib/clever-ruby/event.rb
+++ b/lib/clever-ruby/event.rb
@@ -21,7 +21,7 @@ module Clever
     def object
       klass = APIResource.named type_pieces[0]
       klass ||= CleverObject
-      klass.construct_from data[:object]
+      klass.construct_from data[:object].merge(auth_token: auth_token)
     end
 
     # Get previous attributes before the event

--- a/test/unit/event_test.rb
+++ b/test/unit/event_test.rb
@@ -8,7 +8,8 @@ describe Clever::Event do
       data: {
         object: { id: '512bb9f2ca5e6fa77506133f' }
       },
-      id: '512bb9f2ca5e6fa775061340'
+      id: '512bb9f2ca5e6fa775061340',
+      auth_token: 'blahblahblah'
     )
 
     @updated_event = Clever::Event.construct_from(
@@ -20,12 +21,14 @@ describe Clever::Event do
           last_modified: '2013-03-11T15:38:58.558Z'
         }
       },
-      id: '514767bf80833fb55b1c2dd7'
+      id: '514767bf80833fb55b1c2dd7',
+      auth_token: 'blahblahblah'
     )
   end
 
   it 'creates a clever object for the object the event is about' do
     @event.object.must_be_instance_of Clever::Section
+    @event.object.auth_token.must_equal 'blahblahblah'
   end
 
   it 'knows what action the event is about (created/updated/deleted)' do


### PR DESCRIPTION
This PR fixes a longstanding issue where objects that are off of event objects do not have auth tokens provided, so that making requests to the clever API through those objects will be broken.

# QA

## Reproduce

1. In `rails c`, select a district that has a clever id and has had some events recently.
2. For this district, do `obj = district.events.first.object`
3. Examine this object. Try to access one of its associations. See it fail.
   If it is a teacher object, you could access an association through "obj.sections"
   You can find the list of fetchable associations here: https://clever.com/developers/docs/explorer#resource_teachers

# See Fix

1. switch to the corresponding branch in apangea: jnm+cg/deferred_teacher_actions (https://github.com/thinkthroughmath/apangea/pull/3327)
2. Run through the above steps, but see it return data.
